### PR TITLE
locking in between bookings can cause saldo to become negative (edge case / theoretical)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Style/Documentation:
   Enabled: false
 
 Metrics/ClassLength:
+  Max: 115
   Exclude:
     - "app.rb"
     - "test/api/v1/integration/**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [next] - unreleased
 
+### Fixed
+
+- [#10](https://github.com/simonneutert/ka-ching-backend/pull/10) locking in between can cause saldo to become negative - [@simonneutert](https://github.com/simonneutert).
+
+### Changed
+
 - [#6](https://github.com/simonneutert/ka-ching-backend/pull/6) errors return a status and a message for caught errors of API request - [@simonneutert](https://github.com/simonneutert).
 - [#<PRNUMBER>](https://github.com/simonneutert/ka-ching-backend/pull/<PRNUMBER>) description - [@<username>](https://github.com/<username>).
 

--- a/app.rb
+++ b/app.rb
@@ -259,7 +259,7 @@ class App < Roda
                   locker = Api::V1::Locking::Locker.new(conn, r.params)
                   newest_locking_id = locker.lock!
                   newest_locking = query_lockings(conn).find_by(id: newest_locking_id)
-                rescue Api::V1::Locking::LockingError => e
+                rescue Api::V1::Locking::LockingError, Api::V1::Locking::NegativeSaldoError => e
                   response.status = 403
                   rich_error_return(e, :error_obj)
                 rescue Sequel::CheckConstraintViolation => e


### PR DESCRIPTION
closes #9

- [x] changelog entry
- [x] tests

### recommended

- bump client / sync version
- bump/release next minor