### PR TITLE
Implements Sequel's pg_json extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,7 @@ Style/Documentation:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 115
+  Max: 120
   Exclude:
     - "app.rb"
     - "test/api/v1/integration/**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [next] - unreleased
 
+- [#15](https://github.com/simonneutert/ka-ching-backend/pull/15) implements pg_json extension to quicker deserialize json columns - [@simonneutert](https://github.com/simonneutert).
 - [#<PRNUMBER>](https://github.com/simonneutert/ka-ching-backend/pull/<PRNUMBER>) description - [@<username>](https://github.com/<username>).
 
 ## [0.3.0] - 2023-06-27

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading ka-ching-backend
 
+## >= 0.4.0
+
+### Changes
+
+- [#15](https://github.com/simonneutert/ka-ching-backend/pull/15) Sequel's pg_json extension was added. This is a breaking change, as the database schema was changed, though no migration is provided. Please update your database schema manually or drop the database and start from scratch.
+
 ## 0.2.0 to 0.2.1
 
 ### Changes

--- a/db/migrations/003_create_lockings.rb
+++ b/db/migrations/003_create_lockings.rb
@@ -9,7 +9,7 @@ Sequel.migration do
       Integer :amount_cents_saldo_user_counted, null: false
       TrueClass :active, default: true, index: true, null: false
       DateTime :realized_at, index: true
-      column :bookings_json, :jsonb, null: false
+      column :bookings, :jsonb, null: false
       column :context, :jsonb, null: false
 
       DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP, index: true

--- a/lib/api/v1/locking/locker.rb
+++ b/lib/api/v1/locking/locker.rb
@@ -38,8 +38,8 @@ module Api
 
             bookings = all_bookings_from_range(prelast_locking[:realized_at], @realized_at)
             insert_locking!(saldo_cents_calculated: saldo_cents_calculated,
-                            bookings: bookings.to_json,
-                            context: @context.to_json)
+                            bookings: bookings,
+                            context: @context)
           end
         end
 
@@ -88,10 +88,14 @@ module Api
         end
 
         def insert_locking!(saldo_cents_calculated:, bookings:, context: {})
+          raise ArgumentError unless saldo_cents_calculated.is_a?(Integer)
+          raise ArgumentError unless bookings.is_a?(Array)
+          raise ArgumentError unless context.is_a?(Hash)
+
           @conn_lockings.insert(saldo_cents_calculated: saldo_cents_calculated,
                                 amount_cents_saldo_user_counted: @amount_cents_saldo_user_counted,
                                 realized_at: @realized_at,
-                                bookings_json: bookings,
+                                bookings: bookings.to_json,
                                 context: context.to_json)
         end
 

--- a/lib/api/v1/repository/bookings.rb
+++ b/lib/api/v1/repository/bookings.rb
@@ -44,7 +44,9 @@ module Api
         # @return [Array<Hash>] list of bookings
         #
         def active(last_locking_realized_at, order: :created_at)
-          @conn_bookings.where { realized_at > last_locking_realized_at }.order(order).all
+          @conn_bookings.where { realized_at > last_locking_realized_at }
+                        .order(order)
+                        .all
         end
 
         #
@@ -56,7 +58,10 @@ module Api
         # @return [Array<Hash>] list of bookings
         #
         def active_paginated(last_locking_realized_at, order: :created_at, page: 1, per_page: 100)
-          @conn_bookings.paginate(page, per_page).where { realized_at > last_locking_realized_at }.order(order).all
+          @conn_bookings.paginate(page, per_page)
+                        .where { realized_at > last_locking_realized_at }
+                        .order(order)
+                        .all
         end
       end
     end

--- a/public/docs/api/v1/apiv1.yml
+++ b/public/docs/api/v1/apiv1.yml
@@ -734,7 +734,7 @@ components:
               type: boolean
             realized_at:
               type: string
-            bookings_json:
+            bookings:
               type: string
             context:
               type: string
@@ -748,7 +748,7 @@ components:
             - amount_cents_saldo_user_counted
             - active
             - realized_at
-            - bookings_json
+            - bookings
             - context
             - created_at
             - updated_at
@@ -776,7 +776,7 @@ components:
           type: boolean
         realized_at:
           type: string
-        bookings_json:
+        bookings:
           type: string
         context:
           type: string
@@ -791,7 +791,7 @@ components:
         - amount_cents_saldo_user_counted
         - active
         - realized_at
-        - bookings_json
+        - bookings
         - context
         - created_at
         - updated_at
@@ -908,7 +908,7 @@ components:
               realized_at:
                 type: string
                 example: "2020-01-01"
-              bookings_json:
+              bookings:
                 type: string
                 example: '[{"id":1,"action":"lock","amount_cents":1000,"realized_at":"2020-01-01","context":"{}","created_at":"2020-01-01T00:00:00.000Z","updated_at":"2020-01-01T00:00:00.000Z"}]'
               context:

--- a/test/api/v1/audit_log_test.rb
+++ b/test/api/v1/audit_log_test.rb
@@ -13,8 +13,6 @@ class TestAuditLoggable < ApiIntegrationHelperTest
     @table_name = :lockings
     @before_state = { 'active' => true }
     @result_state = { 'active' => false }
-    @before_state_json = @before_state.to_json
-    @result_state_json = @result_state.to_json
   end
 
   #
@@ -29,8 +27,8 @@ class TestAuditLoggable < ApiIntegrationHelperTest
   def test_create_audit_log_with_single_object_as_result_state
     db.transaction do
       db[:audit_logs].insert(table_referenced: @table_name.to_s,
-                             environment_snapshot: @before_state_json,
-                             log_entry: @result_state_json)
+                             environment_snapshot: @before_state.to_json,
+                             log_entry: @result_state.to_json)
     end
 
     assert_equal(1, db[:audit_logs].count)
@@ -42,12 +40,11 @@ class TestAuditLoggable < ApiIntegrationHelperTest
   def test_create_audit_log_with_complex_hash_of_objects_as_result_state
     @result_state = { 'object1' => { 'active' => false },
                       'object2' => { 'active' => true } }
-    @result_state_json = @result_state.to_json
 
     db.transaction do
       db[:audit_logs].insert(table_referenced: @table_name.to_s,
-                             environment_snapshot: @before_state_json,
-                             log_entry: @result_state_json)
+                             environment_snapshot: @before_state.to_json,
+                             log_entry: @result_state.to_json)
     end
 
     assert_equal(1, db[:audit_logs].count)

--- a/test/api/v1/integration/bookings_test.rb
+++ b/test/api/v1/integration/bookings_test.rb
@@ -270,7 +270,7 @@ class TestBookings < ApiIntegrationHelperTest
     assert(json_body['status'])
     assert_kind_of(Hash, json_body['record'])
     assert_equal(uuid_of_last_booking, json_body['record']['deleted']['id'])
-    assert_kind_of(String, json_body['record']['deleted']['context'])
+    assert_kind_of(Hash, json_body['record']['deleted']['context'])
 
     uri = '/ka-ching/api/v1/test/lockings'
     req_data = { amount_cents_saldo_user_counted: 1999, action: :lock,

--- a/test/api/v1/integration/lockings_test.rb
+++ b/test/api/v1/integration/lockings_test.rb
@@ -103,7 +103,7 @@ class TestLockings < ApiIntegrationHelperTest
     assert_equal(1501, json_body['record']['amount_cents_saldo_user_counted'])
     assert_equal(2000, json_body['record']['saldo_cents_calculated'])
 
-    locked_bookings = JSON.parse(json_body['record']['bookings_json'])
+    locked_bookings = json_body['record']['bookings_json']
     locked_booking = locked_bookings.first
 
     # try deletion of locked booking

--- a/test/api/v1/integration/lockings_test.rb
+++ b/test/api/v1/integration/lockings_test.rb
@@ -103,7 +103,7 @@ class TestLockings < ApiIntegrationHelperTest
     assert_equal(1501, json_body['record']['amount_cents_saldo_user_counted'])
     assert_equal(2000, json_body['record']['saldo_cents_calculated'])
 
-    locked_bookings = json_body['record']['bookings_json']
+    locked_bookings = json_body['record']['bookings']
     locked_booking = locked_bookings.first
 
     # try deletion of locked booking

--- a/test/api/v1/integration/lockings_unlock_test.rb
+++ b/test/api/v1/integration/lockings_unlock_test.rb
@@ -67,7 +67,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
                  year: 2022, month: 11, day: 2 }
     post(uri, JSON.generate(req_data), header_content_type_json)
     json_body = JSON.parse(last_response.body)
-    bookings = json_body['record']['bookings_json']
+    bookings = json_body['record']['bookings']
 
     assert_equal(-499, json_body['diff'])
     assert_equal(2, bookings.count)
@@ -94,7 +94,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
                  year: 2022, month: 11, day: 2 }
     post(uri, JSON.generate(req_data), header_content_type_json)
     json_body = JSON.parse(last_response.body)
-    bookings = json_body['record']['bookings_json']
+    bookings = json_body['record']['bookings']
 
     assert_equal(1, json_body['diff'])
     assert_equal(2, bookings.count)
@@ -123,7 +123,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     assert_equal(-1, json_body['diff'])
     json_body = JSON.parse(last_response.body)
-    bookings = json_body['record']['bookings_json']
+    bookings = json_body['record']['bookings']
 
     assert_equal(1, bookings.count)
 
@@ -145,8 +145,8 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
     latest_locking, *other_bookings = json_body['items']
     first_locking = other_bookings.last
 
-    assert_equal(2, first_locking['bookings_json'].count)
-    assert_equal(1, latest_locking['bookings_json'].count)
+    assert_equal(2, first_locking['bookings'].count)
+    assert_equal(1, latest_locking['bookings'].count)
 
     uri = '/ka-ching/api/v1/test/lockings'
     delete(uri, {}, header_content_type_json)
@@ -172,7 +172,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     json_body = JSON.parse(last_response.body)
 
-    bookings_in_lock = json_body.dig('record', 'bookings_json')
+    bookings_in_lock = json_body.dig('record', 'bookings')
 
     assert_equal 2, bookings_in_lock.count
     assert_equal(-499, json_body['diff'])
@@ -200,7 +200,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     assert_predicate last_response, :ok?
     json_body = JSON.parse(last_response.body)
-    bookings_in_lock = json_body.dig('record', 'bookings_json')
+    bookings_in_lock = json_body.dig('record', 'bookings')
 
     assert_equal 1, bookings_in_lock.count
     assert_equal 0, json_body['diff']
@@ -218,7 +218,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
     assert_predicate last_response, :ok?
     json_body = JSON.parse(last_response.body)
 
-    bookings_in_lock = json_body.dig('record', 'bookings_json')
+    bookings_in_lock = json_body.dig('record', 'bookings')
 
     assert_equal 1, bookings_in_lock.count
     assert_equal(-1, json_body['diff'])

--- a/test/api/v1/integration/lockings_unlock_test.rb
+++ b/test/api/v1/integration/lockings_unlock_test.rb
@@ -67,7 +67,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
                  year: 2022, month: 11, day: 2 }
     post(uri, JSON.generate(req_data), header_content_type_json)
     json_body = JSON.parse(last_response.body)
-    bookings = JSON.parse(json_body['record']['bookings_json'])
+    bookings = json_body['record']['bookings_json']
 
     assert_equal(-499, json_body['diff'])
     assert_equal(2, bookings.count)
@@ -94,7 +94,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
                  year: 2022, month: 11, day: 2 }
     post(uri, JSON.generate(req_data), header_content_type_json)
     json_body = JSON.parse(last_response.body)
-    bookings = JSON.parse(json_body['record']['bookings_json'])
+    bookings = json_body['record']['bookings_json']
 
     assert_equal(1, json_body['diff'])
     assert_equal(2, bookings.count)
@@ -123,7 +123,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     assert_equal(-1, json_body['diff'])
     json_body = JSON.parse(last_response.body)
-    bookings = JSON.parse(json_body['record']['bookings_json'])
+    bookings = json_body['record']['bookings_json']
 
     assert_equal(1, bookings.count)
 
@@ -145,8 +145,8 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
     latest_locking, *other_bookings = json_body['items']
     first_locking = other_bookings.last
 
-    assert_equal(2, JSON.parse(first_locking['bookings_json']).count)
-    assert_equal(1, JSON.parse(latest_locking['bookings_json']).count)
+    assert_equal(2, first_locking['bookings_json'].count)
+    assert_equal(1, latest_locking['bookings_json'].count)
 
     uri = '/ka-ching/api/v1/test/lockings'
     delete(uri, {}, header_content_type_json)
@@ -174,7 +174,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     bookings_in_lock = json_body.dig('record', 'bookings_json')
 
-    assert_equal 2, JSON.parse(bookings_in_lock).count
+    assert_equal 2, bookings_in_lock.count
     assert_equal(-499, json_body['diff'])
 
     uri = '/ka-ching/api/v1/test/lockings'
@@ -202,7 +202,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
     json_body = JSON.parse(last_response.body)
     bookings_in_lock = json_body.dig('record', 'bookings_json')
 
-    assert_equal 1, JSON.parse(bookings_in_lock).count
+    assert_equal 1, bookings_in_lock.count
     assert_equal 0, json_body['diff']
 
     uri = '/ka-ching/api/v1/test/lockings'
@@ -220,7 +220,7 @@ class TestLockingsUnlock < ApiIntegrationHelperTest
 
     bookings_in_lock = json_body.dig('record', 'bookings_json')
 
-    assert_equal 1, JSON.parse(bookings_in_lock).count
+    assert_equal 1, bookings_in_lock.count
     assert_equal(-1, json_body['diff'])
 
     uri = '/ka-ching/api/v1/test/lockings'

--- a/test/api/v1/integration/tenants_pagination_test.rb
+++ b/test/api/v1/integration/tenants_pagination_test.rb
@@ -43,6 +43,18 @@ class TestTenantsPagination < ApiIntegrationHelperTest
     assert_equal(1000, json_body['page_size'])
     assert(json_body['items'].is_a?(Array))
     refute_empty(json_body['items'])
-    assert_equal(%w[id tenant_db_id active current_state next_state context created_at updated_at].sort, json_body['items'][0].keys.sort)
+    assert_equal(
+      %w[
+        id
+        tenant_db_id
+        active
+        current_state
+        next_state
+        context
+        created_at
+        updated_at
+      ].sort,
+      json_body['items'][0].keys.sort
+    )
   end
 end

--- a/test/api/v1/param_casters/booking_params_test.rb
+++ b/test/api/v1/param_casters/booking_params_test.rb
@@ -46,7 +46,7 @@ class TestBookingParams < ApiIntegrationHelperTest
     assert_equal(2022, booking.year)
     assert_equal(10, booking.month)
     assert_equal(11, booking.day)
-    assert_kind_of(String, booking.context.to_json)
+    assert_kind_of(Hash, booking.context)
     assert_empty(%i[@action @amount_cents @year @month @day @context] - booking.instance_variables)
   end
 end

--- a/test/api/v1/param_casters/locking_params_test.rb
+++ b/test/api/v1/param_casters/locking_params_test.rb
@@ -50,7 +50,7 @@ class TestLockingParams < ApiIntegrationHelperTest
     assert_equal(2022, locking.year)
     assert_equal(10, locking.month)
     assert_equal(11, locking.day)
-    assert_kind_of(String, locking.context.to_json)
+    assert_kind_of(Hash, locking.context)
 
     assert_empty(%i[@action @amount_cents_saldo_user_counted @year @month @day @context] - locking.instance_variables)
   end


### PR DESCRIPTION
closes #14

relates to client PR: https://github.com/simonneutert/ka-ching-client/pull/18

implements Sequel's pg_json extension ([docs](https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/pg_json_rb.html))