### PR TITLE
chore: fixes gem logger warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Schema for new entries:
 ## [unreleased] - yyyy-mm-dd
 
 - [#<PRNUMBER>](https://github.com/simonneutert/ka-ching-backend/pull/<PRNUMBER>) description - [@<username>](https://github.com/<username>)
+- [#110](https://github.com/simonneutert/ka-ching-backend/pull/110) loads `logger` gem from rubygems not standardlib - [@simonneutert](https://github.com/simonneutert)
 
 ## [0.7.0] - 2025-09-14
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'bigdecimal', '~> 3.2'
+gem 'logger', '~> 1.7'
 gem 'puma', '~> 7.0'
 gem 'rack-unreloader', '~> 2.0'
 gem 'rackup', '~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,9 +25,21 @@ GEM
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     ostruct (0.6.3)
@@ -35,7 +47,13 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    pg (1.5.9)
+    pg (1.6.2)
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-aarch64-linux-musl)
+    pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-darwin)
+    pg (1.6.2-x86_64-linux)
+    pg (1.6.2-x86_64-linux-musl)
     prism (1.5.1)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -126,13 +144,21 @@ GEM
       yard (~> 0.9)
 
 PLATFORMS
-  aarch64-darwin
-  arm64-darwin-22
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   bigdecimal (~> 3.2)
+  logger (~> 1.7)
   minitest (~> 5.25)
   minitest-hooks (~> 1.5)
   pry (~> 0.15.2)
@@ -152,4 +178,4 @@ DEPENDENCIES
   solargraph
 
 BUNDLED WITH
-   2.6.5
+   2.7.2


### PR DESCRIPTION
`logger` was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.

---

This pull request updates the project to explicitly load the `logger` gem from RubyGems instead of relying on the standard library. This change is documented in the changelog and reflected in the `Gemfile`.

Dependency management:

* Added the `logger` gem (version `~> 1.7`) to the `Gemfile` to ensure it is loaded from RubyGems rather than the standard library.

Documentation:

* Updated the `CHANGELOG.md` to record the change regarding the `logger` gem source.